### PR TITLE
change release to 0.5 in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: julia
 ## If you leave the julia: key out of your .travis.yml, Travis CI will use the most recent release.
 julia:
   - 0.4
-  - release
+  - 0.5
   - nightly
 os:
   - linux


### PR DESCRIPTION
these are equivalent right now, but once 0.6 comes out release will change
and this would no longer be testing against 0.5