### PR TITLE
32 bit compatibility

### DIFF
--- a/src/gradcheck.jl
+++ b/src/gradcheck.jl
@@ -195,7 +195,7 @@ function fixtest(f, x...)
 end
 
 function randin(range, dims...; eps=0.01)
-    if isa(range, UnitRange{Int64})
+    if isa(range, UnitRange{Int})
         rand(range, dims...)
     elseif range==(-Inf,Inf)
         randn(dims...)


### PR DESCRIPTION
The `UnitRange{Int64}` case in `randin` doesn't match the `0:5` range used in the test of `gamma.jl` for 32 bit Julia.