### PR TITLE
seed explicitly MersenneTwister(0)

### DIFF
--- a/src/gradcheck.jl
+++ b/src/gradcheck.jl
@@ -125,7 +125,7 @@ function gc_interval(w,d)
 end
 
 function gc_scalar(f)
-    r = MersenneTwister()
+    r = MersenneTwister(0)
     function g(x...; o...)
         srand(r,1)
         y = f(x...; o...)

--- a/src/util.jl
+++ b/src/util.jl
@@ -293,7 +293,7 @@ function unbroadcast(x, dx)
     end
 end
 
-function toscalar(xv; rng=MersenneTwister())
+function toscalar(xv; rng=MersenneTwister(0))
     x = getval(xv)
     isa(x,Number) && return xv
     isa(x,UngetIndex) && (x = full(x))


### PR DESCRIPTION
The default constructor `MersenneTwister(0)` will be deprecated, cf. https://github.com/JuliaLang/julia/pull/16984#issuecomment-290914407.