### PR TITLE
support julia v0.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ language: julia
 julia:
   - 0.4
   - 0.5
+  - 0.6
   - nightly
 os:
   - linux

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Build Status](https://travis-ci.org/denizyuret/AutoGrad.jl.svg?branch=master)](https://travis-ci.org/denizyuret/AutoGrad.jl)
 [![AutoGrad](http://pkg.julialang.org/badges/AutoGrad_0.4.svg)](http://pkg.julialang.org/?pkg=AutoGrad)
 [![AutoGrad](http://pkg.julialang.org/badges/AutoGrad_0.5.svg)](http://pkg.julialang.org/?pkg=AutoGrad)
+[![AutoGrad](http://pkg.julialang.org/badges/AutoGrad_0.6.svg)](http://pkg.julialang.org/?pkg=AutoGrad)
 <!-- 
 TODO: https://github.com/JuliaCI/Coverage.jl
 [![Coverage Status](https://coveralls.io/repos/denizyuret/AutoGrad.jl/badge.svg)](https://coveralls.io/r/denizyuret/AutoGrad.jl)

--- a/src/base/broadcast.jl
+++ b/src/base/broadcast.jl
@@ -17,7 +17,8 @@ broadcast2arg = [
 ]
 
 for (f,g1,g2) in broadcast2arg
-    @eval @primitive $f(x1,x2),dy,y  unbroadcast(x1,$g1)  unbroadcast(x2,$g2)
+    bf = broadcast_func(f)
+    @eval @primitive $bf(x1,x2),dy,y  unbroadcast(x1,$g1)  unbroadcast(x2,$g2)
     if f==(:.^)
         addtest3(f,(0,Inf))
     else
@@ -47,11 +48,12 @@ broadcast2cmp = [
 ]                 
 
 for f in broadcast2cmp
+    bf = broadcast_func(f)
     @eval begin
         # To avoid conflict at broadcast.jl:414
         $f(x1::AbstractArray,x2::Rec)=$f(x1,x2.value)
         $f(x1::Rec,x2::AbstractArray)=$f(x1.value,x2)
-        @zerograd $f(x1,x2)
+        @zerograd $bf(x1,x2)
     end
 end
 

--- a/src/base/math.jl
+++ b/src/base/math.jl
@@ -22,7 +22,9 @@ math1arg = [
 ]
 
 for (f,g,r) in math1arg
+    bf = broadcast_func(f)
     @eval @primitive $f(x),dy,y  (dy.*($g))
+    @eval @primitive $bf(x),dy,y  (dy.*($g))
     addtest1(f,r)
 end
 
@@ -40,42 +42,57 @@ end
 # gradient definitions.
 
 math2arg = [
-(:atan2, :(x2./(abs2(x1)+abs2(x2))), :(-x1./(abs2(x1)+abs2(x2)))),
-(:hypot, :(x1./y), :(x2./y)),
-(:max, :(y.==x1), :(y.==x2)),
-(:min, :(y.==x1), :(y.==x2)),
+(:atan2, quote x2./(abs2(x1)+abs2(x2)) end, quote -x1./(abs2(x1)+abs2(x2)) end),
+(:hypot, quote x1./y end, quote x2./y end),
+(:max, quote y.==x1 end, quote y.==x2 end),
+(:min, quote y.==x1 end, quote y.==x2 end),
 ]
 
 for (f,g1,g2) in math2arg
+    bf = broadcast_func(f)
     @eval @primitive $f(x1,x2),dy,y  unbroadcast(x1,dy.*($g1))  unbroadcast(x2,dy.*($g2))
+    @eval @primitive $bf(x1,x2),dy,y  unbroadcast(x1,dy.*($g1))  unbroadcast(x2,dy.*($g2))
     addtest2(f,(-Inf,Inf))
 end
 
 # The 2-arg log supports positive args for reals.
 log(x1::Irrational{:e},x2::Rec)=log(float(x1),x2) # to avoid clash with irrationals.jl:131.
-@primitive log(x1,x2),dy  unbroadcast(x1,-dy.*log(x2)./(x1.*abs2(log(x1))))  unbroadcast(x2,dy./(x2.*log(x1)))
+@primitive log(x1,x2),dy  unbroadcast(x1,begin -dy.*log(x2) end./begin x1.*abs2(log(x1)) end)  unbroadcast(x2,dy./begin x2.*log(x1) end)
+if VERSION > v"0.6-"
+    bf = Symbol("broadcast#log")
+    @eval @primitive $bf(x1,x2),dy  unbroadcast(x1,begin -dy.*log(x2) end./begin x1.*abs2(log(x1)) end)  unbroadcast(x2,dy./begin x2.*log(x1) end)
+end
 addtest2(log,(0,Inf))
 
 # ^ only supports (N>=0,N), arrays not supported in math.jl, only M^N in linalg/dense.jl (TODO)
 (^){T<:Number}(x1::Rec{T},x2::Integer)=(^)(x1,float(x2)) # to avoid clash with intfuncs:108
+(^)(x1::Broadcasted,x2::Integer)=(^)(x1,float(x2)) # to avoid clash with intfuncs:108
 @primitive (^)(x1::Number,x2::Number),dy,y  (dy*x2*x1^(x2-1))  (dy*y*log(x1))
 addtest(^, randin((0,Inf)), randin((-Inf,Inf)))
 
 # clamp(x,lo,hi) clamps x between lo and hi
+bf = broadcast_func(:clamp)
 @primitive clamp(x,i...),dy,y  unbroadcast(x,dy.*(i[1] .<= x .<= i[2]))
+@eval @primitive $bf(x,i...),dy,y  unbroadcast(x,dy.*(i[1] .<= x .<= i[2]))
 addtest(clamp, randn(10), -1., 1.)
 addtest(clamp, randn(), -1., 1.)
 
 # ldexp(x,n) computes x*2^n with x real, n integer
+bf = broadcast_func(:ldexp)
 @primitive ldexp(x,n...),dy  (dy*(2.0^n[1]))
+@eval @primitive $bf(x,n...),dy  (dy*(2.0^n[1]))
 addtest(ldexp, randn(), rand(-2:2))
 
 # mod2pi(x) returns modulus after division by 2pi for x real.
+bf = broadcast_func(:mod2pi)
 @primitive mod2pi(x::Number),dy dy
+@eval @primitive $bf(x::Number),dy dy
 addtest(mod2pi, 100randn())
 
 # zerograd functions
+bf = broadcast_func(:exponent)
 @zerograd exponent(x)
+@eval @zerograd $bf(x)
 
 
 # Other functions defined in julia/base/math.jl

--- a/src/util.jl
+++ b/src/util.jl
@@ -329,7 +329,7 @@ end
 
 # Pretty print for debugging:
 _dbg(x)=summary(x) # extend to define short printable representations
-_dbg(x::Tuple)=map(_dbg,x)
+_dbg(x::Tuple)=string(map(_dbg,x)...)
 _dbg(x::Node)=_dbg(x.rec.value)*"N"
 _dbg(x::Rec)=_dbg(x.value)*"R"
 _dbg(x::Tape)="N"*ssize(x)
@@ -359,5 +359,33 @@ function dumptape(t::Tape)
         end
         f = r.func
         @printf("%d. %s%s\n", i, f, p)
+    end
+end
+
+type Broadcasted{T}
+    value::T
+end
+
+broadcast(f, x::Rec) = f(Broadcasted(x)).value
+broadcast(f, x1::Rec, x2) = f(Broadcasted(x1), x2).value
+broadcast(f, x1, x2::Rec) = f(x1, Broadcasted(x2)).value
+broadcast(f, x1::Rec, x2::Rec) = f(Broadcasted(x1), Broadcasted(x2)).value
+
+function broadcast_func(f)
+    if VERSION > v"0.6-"
+        f = Symbol(lstrip(String(f), '.'))
+        bf = Symbol("broadcast#", f)
+        @eval begin
+            $bf(x) = broadcast($f, x)
+            $bf(x1, x2) = broadcast($f, x1, x2)
+            
+            $f(x::Broadcasted) = $bf(x.value) |> Broadcasted
+            $f(x1::Broadcasted, x2) = $bf(x1.value, x2) |> Broadcasted
+            $f(x1, x2::Broadcasted) = $bf(x1, x2.value) |> Broadcasted
+            $f(x1::Broadcasted, x2::Broadcasted) = $bf(x1.value, x2.value) |> Broadcasted
+        end
+        bf
+    else
+        f
     end
 end


### PR DESCRIPTION
This PR makes AutoGrad work in Julia v0.6 by

1. overload the broadcast operations deprecated in Julia v0.6 by [this trick](https://github.com/JuliaLang/julia/issues/22060#issuecomment-304294397).
2. circumvent some broadcast fusing by using blocks (`begin ... end`) in gradient expressions.
3. fix a little bug in `_dbg(x::Tuple)` which crashes when called with something like `Rec{Tuple{Float64, Float64}}`

Though it raises a lot of warnings, this branch passes the tests on Julia 0.6.0.