### PR TITLE
drop julia 0.4 + add support for special functions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: julia
 ## https://docs.travis-ci.com/user/languages/julia
 ## If you leave the julia: key out of your .travis.yml, Travis CI will use the most recent release.
 julia:
-  - 0.4
   - 0.5
   - 0.6
   - nightly

--- a/README.md
+++ b/README.md
@@ -1,13 +1,11 @@
 # AutoGrad
 
 [![Build Status](https://travis-ci.org/denizyuret/AutoGrad.jl.svg?branch=master)](https://travis-ci.org/denizyuret/AutoGrad.jl)
-[![AutoGrad](http://pkg.julialang.org/badges/AutoGrad_0.4.svg)](http://pkg.julialang.org/?pkg=AutoGrad)
 [![AutoGrad](http://pkg.julialang.org/badges/AutoGrad_0.5.svg)](http://pkg.julialang.org/?pkg=AutoGrad)
 [![AutoGrad](http://pkg.julialang.org/badges/AutoGrad_0.6.svg)](http://pkg.julialang.org/?pkg=AutoGrad)
-<!-- 
+<!--
 TODO: https://github.com/JuliaCI/Coverage.jl
 [![Coverage Status](https://coveralls.io/repos/denizyuret/AutoGrad.jl/badge.svg)](https://coveralls.io/r/denizyuret/AutoGrad.jl)
-[![AutoGrad](http://pkg.julialang.org/badges/AutoGrad_0.3.svg)](http://pkg.julialang.org/?pkg=AutoGrad)
 -->
 
 AutoGrad.jl is an automatic differentiation package for Julia.  It is

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,3 @@
-julia 0.4
+julia 0.5
 Compat 0.8.1 # allunique
+SpecialFunctions

--- a/src/AutoGrad.jl
+++ b/src/AutoGrad.jl
@@ -1,7 +1,8 @@
-VERSION >= v"0.4.0-dev+6521" && __precompile__()
+__precompile__()
 
 module AutoGrad
 using Compat
+using SpecialFunctions # erf, bessel,...
 
 # utilities for debugging and profiling.
 macro dbg(i,x); if i & 0 != 0; esc(:(println(_dbg($x)))); end; end;
@@ -30,10 +31,10 @@ include("linalg/matmul.jl")
 include("linalg/dense.jl")
 include("linalg/generic.jl")
 include("special/trig.jl")
-if VERSION < v"0.6.0"
-    include("special/bessel.jl") ### Removed from Base in Julia6
-    include("special/erf.jl")    ### Removed from Base in Julia6
-    include("special/gamma.jl")  ### Removed from Base in Julia6
-end
+
+# functions in SpecialFunctions.jl
+include("special/bessel.jl")
+include("special/erf.jl")
+include("special/gamma.jl")
 
 end # module

--- a/src/core.jl
+++ b/src/core.jl
@@ -128,7 +128,7 @@ function rfun(args...; kwargs...)
             tape = arg.tapes[t]
             iscomplete(tape) && continue
             parent = arg.nodes[t]
-            if !isa(result,Rec) 
+            if !isa(result,Rec)
                 result = Rec(result, tape; func=f, args=args, kwargs=kwargs)
                 rnode = result.nodes[1]
             else
@@ -179,23 +179,7 @@ Unbox `x` if it is a boxed value (`Rec`), otherwise return `x`.
 """
 getval(x) = (if isa(x, Rec); x.value; else; x; end)  # we never create Rec(Rec).
 
-if VERSION >= v"0.5.0"
-    unbox(args) = map(getval,args)
-else
-    # this is much faster than map(getval,args) in Julia4
-    function unbox(args)
-        vals = Array{Any}(length(args))
-        @inbounds for i=1:length(args)
-            ai = args[i]
-            if isa(ai,Rec)
-                vals[i] = ai.value
-            else
-                vals[i] = ai
-            end
-        end
-        return vals
-    end
-end
+unbox(args) = map(getval,args)
 
 # findfirst uses == which is inefficient for tapes, so we define findeq with ===
 function findeq(A,v)
@@ -354,7 +338,7 @@ let eot = Node(Rec(nothing))
     iscomplete(a::Tape)=(!isempty(a) && a[end]===eot)
     complete!(a::Tape)=push!(a,eot)
 end # let
-end # if 
+end # if
 
 
 # 6. How new primitives and their gradients are defined.
@@ -410,7 +394,7 @@ end # if
 # 6.2 Gradients
 
 if !isdefined(:Grad)
-"Grad{N} creates a type used by AutoGrad to represent the gradient wrt N'th arg."    
+"Grad{N} creates a type used by AutoGrad to represent the gradient wrt N'th arg."
 immutable Grad{N}; end
 end
 
@@ -522,5 +506,3 @@ sum_outgrads(::Void,a)=a
 # backward_pass(g) calls gradient methods recorded in t1.
 # even though some inputs are Recs again, nothing gets recorded and all primitives return values because t1 is complete.
 # backward_pass(g) returns a regular value which becomes the output of h(x).
-
-

--- a/src/interfaces.jl
+++ b/src/interfaces.jl
@@ -240,10 +240,8 @@ interfacesNarg = [
 
 @zerograd similar(x)
 
-if VERSION >= v"0.5.0"
 # to prevent ambiguity with abstractarray.jl:470
 @zerograd similar(x, dims::Base.DimOrInd...)
-end
 
 for _f in interfacesNarg
     @eval @zerograd $_f(x,i...)

--- a/test/header.jl
+++ b/test/header.jl
@@ -1,8 +1,3 @@
-if VERSION >= v"0.5.0-dev+7720"
-    using Base.Test
-else
-    using BaseTestNext
-    const Test = BaseTestNext
-end
+using Base.Test
 
 using AutoGrad

--- a/test/interfaces.jl
+++ b/test/interfaces.jl
@@ -1,10 +1,5 @@
 include("header.jl")
 
-# http://docs.julialang.org/en/latest/manual/arrays.html#man-supported-index-types-1
-if VERSION < v"0.5.0"
-    Base.IteratorsMD.CartesianIndex(i::Int...)=CartesianIndex(i)
-end
-
 @testset "interfaces" begin
 
     @testset "Array" begin


### PR DESCRIPTION
In order to add back support for special functions and fix #27  I add to add SpecialFunctions.jl to REQUIRE and drop support for julia 0.4, since SpecialFunctions is not tagged on 0.4 

I hope it is ok for AutoGrad 0.0.8 to be the last version to support julia 0.4. One could also think of dropping compatibility with 0.5 soon, to easy maintenance and prepare in advance for the changes that will be introduced with 0.7.

Bye,
Carlo