### PR TITLE
add back support for erfs on 0.6

### DIFF
--- a/src/AutoGrad.jl
+++ b/src/AutoGrad.jl
@@ -2,6 +2,9 @@ VERSION >= v"0.4.0-dev+6521" && __precompile__()
 
 module AutoGrad
 using Compat
+if VERSION >= v"0.6.0" && Pkg.installed("SpecialFunctions") != nothing
+    using SpecialFunctions
+end
 
 # utilities for debugging and profiling.
 macro dbg(i,x); if i & 0 != 0; esc(:(println(_dbg($x)))); end; end;
@@ -32,8 +35,10 @@ include("linalg/generic.jl")
 include("special/trig.jl")
 if VERSION < v"0.6.0"
     include("special/bessel.jl") ### Removed from Base in Julia6
-    include("special/erf.jl")    ### Removed from Base in Julia6
     include("special/gamma.jl")  ### Removed from Base in Julia6
+end
+if VERSION < v"0.6.0" || Pkg.installed("SpecialFunctions") != nothing
+    include("special/erf.jl")    ### Removed from Base in Julia6
 end
 
 end # module


### PR DESCRIPTION
non-invasive version of #28 

For some reason unclear to me, I could only add back the error functions, since the other functions are not properly broadcasted (maybe) and I keep getting test failures like:
```julia
primitives: Error During Test
  Test threw an exception of type ErrorException
  Expression: gradcheck(eval(AutoGrad, t[1]), t[2:end]...)
  besselj0([0.723138, -0.112219],) has been moved to the package SpecialFunctions.jl.
  Run Pkg.add("SpecialFunctions") to install SpecialFunctions on Julia v0.6 and later,
  and then run `using SpecialFunctions`.
  Stacktrace:
   [1] besselj0(::Array{Float64,1}) at ./deprecated.jl:1294
   [2] (::AutoGrad.##rfun#7#10{Base.#besselj0})(::Array{Any,1}, ::Function, ::AutoGrad.Rec{Array{Float64,1}}, ::Vararg{AutoGrad.Rec{Array{Float64,1}},N} where N) at /home/carlo/Git/AutoGrad.jl/src/core.jl:123
   [3] broadcast#besselj1(::Type{AutoGrad.Grad{1}}, ::Array{Float64,1}, ::Array{Float64,1}, ::AutoGrad.Rec{Array{Float64,1}}) at ./<missing>:0
   [4] backward_pass(::AutoGrad.Rec{Array{Float64,1}}, ::AutoGrad.Rec{Float64}, ::Array{AutoGrad.Node,1}) at /home/carlo/Git/AutoGrad.jl/src/core.jl:254
   [5] (::AutoGrad.##gradfun#1#3{AutoGrad.#g#22,Int64})(::Array{Any,1}, ::Function, ::Array{Float64,1}, ::Vararg{Any,N} where N) at /home/carlo/Git/AutoGrad.jl/src/core.jl:40
   [6] (::AutoGrad.#gradfun#2)(::Array{Float64,1}, ::Vararg{Any,N} where N) at /home/carlo/Git/AutoGrad.jl/src/core.jl:39
   [7] #gradcheck#17(::Array{Any,1}, ::Array{Any,1}, ::Function, ::Function, ::Array{Float64,1}) at /home/carlo/Git/AutoGrad.jl/src/gradcheck.jl:39
   [8] gradcheck(::Function, ::Array{Float64,1}) at /home/carlo/Git/AutoGrad.jl/src/gradcheck.jl:36
   [9] macro expansion at /home/carlo/Git/AutoGrad.jl/test/primitives.jl:6 [inlined]
   [10] macro expansion at ./test.jl:860 [inlined]
   [11] anonymous at ./<missing>:?
```