### PR TITLE
remove @printf to avoid importing Printf in v0.7

### DIFF
--- a/src/core.jl
+++ b/src/core.jl
@@ -157,7 +157,7 @@ function rfun(args...; kwargs...)
                 0
             end
         end
-        @printf("%d. %s%s\n", i, f, p)
+        println("$i. $f$p")
     end
     @dbg 1 (:call, f, :y, result, :x, args..., (isempty(kwargs) ? () : (:kw, kwargs...))...)
 end # prof begin

--- a/src/util.jl
+++ b/src/util.jl
@@ -359,7 +359,7 @@ function dumptape(t::Tape)
             isassigned(n.parents,j) ? findfirst(t,n.parents[j]) : 0
         end
         f = r.func
-        @printf("%d. %s%s\n", i, f, p)
+        println("$i. $f$p")
     end
 end
 


### PR DESCRIPTION
Was trying to make v0.7 compatible, but after fixing this I ran into another error:
```
ERROR: LoadError: LoadError: syntax: invalid let syntax
Stacktrace:
 [1] include at ./boot.jl:295 [inlined]
 [2] include_relative(::Module, ::String) at ./loading.jl:521
 [3] include at ./sysimg.jl:26 [inlined]
 [4] include(::String) at /home/dss/.julia/v0.7/AutoGrad/src/AutoGrad.jl:3
 [5] top-level scope
 [6] include at ./boot.jl:295 [inlined]
 [7] include_relative(::Module, ::String) at ./loading.jl:521
 [8] include(::Module, ::String) at ./sysimg.jl:26
 [9] top-level scope
 [10] eval at ./boot.jl:298 [inlined]
 [11] top-level scope at ./<missing>:2
in expression starting at /home/dss/.julia/v0.7/AutoGrad/src/util.jl:312
in expression starting at /home/dss/.julia/v0.7/AutoGrad/src/AutoGrad.jl:30
```

I didn't know how to fix the macro, so I am just submitting this as a token effort toward v0.7 compatibility.