### PR TITLE
Make AutoGrad run in Julia v0.6+v0.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ language: julia
 ## If you leave the julia: key out of your .travis.yml, Travis CI will use the most recent release.
 julia:
   - 0.6
+  - 0.7
   - nightly
 os:
   - linux

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -120,6 +120,9 @@ git-tree-sha1 = "1cf00baba50536d254f02082c90b98d6e4e1f968"
 uuid = "276daf66-3868-5448-9aa4-cd146d93841b"
 version = "0.6.0"
 
+[[Statistics]]
+uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+
 [[Test]]
 uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,8 +1,8 @@
 [[AbstractFFTs]]
-deps = ["LinearAlgebra"]
-git-tree-sha1 = "f15c60f62d175e65f4b11e865adbe9ba3c821eac"
+deps = ["Compat", "LinearAlgebra"]
+git-tree-sha1 = "8d59c3b1463b5e0ad05a3698167f85fac90e184d"
 uuid = "621f4979-c628-5d54-868e-fcf4e3e8185c"
-version = "0.3.1"
+version = "0.3.2"
 
 [[Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
@@ -13,17 +13,29 @@ git-tree-sha1 = "160d5d926e83e0970dd549ad9fe0ac3e8107e83c"
 uuid = "9e28174c-4ba2-5203-b857-d8d62c4213ee"
 version = "0.8.8"
 
+[[BinaryProvider]]
+deps = ["Compat", "Pkg", "SHA"]
+git-tree-sha1 = "94dac52c662ca793008fb689e3daf626b6139943"
+uuid = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
+version = "0.3.3"
+
 [[Compat]]
-deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "IterativeEigensolvers", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "SuiteSparse", "Test", "UUIDs", "Unicode"]
-git-tree-sha1 = "e891dc2ba653107604985bc5ab7294d9de83630f"
+deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Test", "UUIDs", "Unicode"]
+git-tree-sha1 = "f3e87ca1e2df8e1e4f82ea504fddf0b9b0894f61"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
-version = "0.66.0"
+version = "0.69.0"
+
+[[Conda]]
+deps = ["BinDeps", "Compat", "JSON", "Libdl", "VersionParsing"]
+git-tree-sha1 = "6358e179fb9ad0af5ca9cd4d7c691c413cc121f2"
+uuid = "8f4d0f93-b110-5947-807f-2305c1781a2d"
+version = "0.8.1"
 
 [[DSP]]
-deps = ["AbstractFFTs", "Compat", "FFTW", "Polynomials", "Reexport", "SpecialFunctions"]
-git-tree-sha1 = "0ac99956e1ac6bccbcdae0a924ecfa61363d45c7"
+deps = ["AbstractFFTs", "Compat", "FFTW", "LinearAlgebra", "Polynomials", "Reexport", "SpecialFunctions"]
+git-tree-sha1 = "c0f6a5033c7729a3428e0ef6843eb34263c437ca"
 uuid = "717857b8-e6f2-59f4-9121-6e50c889abd2"
-version = "0.4.0"
+version = "0.5.0"
 
 [[Dates]]
 uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
@@ -35,16 +47,19 @@ uuid = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 
 [[FFTW]]
-deps = ["AbstractFFTs", "BinDeps", "Compat", "Libdl", "LinearAlgebra", "Reexport", "Test"]
-git-tree-sha1 = "678106e8c300595a5643dbbca624e39bcb200cad"
+deps = ["AbstractFFTs", "BinaryProvider", "Compat", "Conda", "Libdl", "LinearAlgebra", "Reexport", "Test"]
+git-tree-sha1 = "60346335ad3aa60bfbdc358c6d1468bffbcff071"
 uuid = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
-version = "0.2.2"
+version = "0.2.3"
 
 [[InteractiveUtils]]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 
-[[IterativeEigensolvers]]
-uuid = "de555fa4-b82f-55e7-8b71-53f60bbc027d"
+[[JSON]]
+deps = ["Dates", "Distributed", "Mmap", "Sockets", "Test", "Unicode"]
+git-tree-sha1 = "723a515212612b2175095fa5fa55da0bb4c377e5"
+uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+version = "0.18.0"
 
 [[LibGit2]]
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
@@ -66,9 +81,9 @@ uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
 [[Polynomials]]
 deps = ["Compat"]
-git-tree-sha1 = "4c709222e10c370030cb417055bd69564fa089fe"
+git-tree-sha1 = "23d095b4c1ecbacd78bb0eea6b85d6e0872ce3bd"
 uuid = "f27b6e38-b328-58d1-80ce-0feddd5e7a45"
-version = "0.3.0"
+version = "0.4.0"
 
 [[Printf]]
 uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
@@ -100,13 +115,10 @@ uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
 uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [[SpecialFunctions]]
-deps = ["BinDeps", "Compat", "Libdl"]
-git-tree-sha1 = "a674e75798a737de67d6860b29a9e56a13d7639f"
+deps = ["BinDeps", "BinaryProvider", "Compat", "Libdl"]
+git-tree-sha1 = "1cf00baba50536d254f02082c90b98d6e4e1f968"
 uuid = "276daf66-3868-5448-9aa4-cd146d93841b"
-version = "0.4.0"
-
-[[SuiteSparse]]
-uuid = "4607b0f0-06f3-5cda-b6b1-a6196a1729e9"
+version = "0.6.0"
 
 [[Test]]
 uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
@@ -122,3 +134,9 @@ uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [[Unicode]]
 uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+
+[[VersionParsing]]
+deps = ["Compat"]
+git-tree-sha1 = "e8524bb636735227fd9d750dfa81f98db8bc5b0c"
+uuid = "81def892-9a0e-5fdd-b105-ffc91e053289"
+version = "1.1.1"

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,0 +1,124 @@
+[[AbstractFFTs]]
+deps = ["LinearAlgebra"]
+git-tree-sha1 = "f15c60f62d175e65f4b11e865adbe9ba3c821eac"
+uuid = "621f4979-c628-5d54-868e-fcf4e3e8185c"
+version = "0.3.1"
+
+[[Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[[BinDeps]]
+deps = ["Compat", "Libdl", "SHA", "URIParser"]
+git-tree-sha1 = "160d5d926e83e0970dd549ad9fe0ac3e8107e83c"
+uuid = "9e28174c-4ba2-5203-b857-d8d62c4213ee"
+version = "0.8.8"
+
+[[Compat]]
+deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "IterativeEigensolvers", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "SuiteSparse", "Test", "UUIDs", "Unicode"]
+git-tree-sha1 = "e891dc2ba653107604985bc5ab7294d9de83630f"
+uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
+version = "0.66.0"
+
+[[DSP]]
+deps = ["AbstractFFTs", "Compat", "FFTW", "Polynomials", "Reexport", "SpecialFunctions"]
+git-tree-sha1 = "0ac99956e1ac6bccbcdae0a924ecfa61363d45c7"
+uuid = "717857b8-e6f2-59f4-9121-6e50c889abd2"
+version = "0.4.0"
+
+[[Dates]]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+
+[[DelimitedFiles]]
+uuid = "8bb1440f-4735-579b-a4ab-409b98df4dab"
+
+[[Distributed]]
+uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+
+[[FFTW]]
+deps = ["AbstractFFTs", "BinDeps", "Compat", "Libdl", "LinearAlgebra", "Reexport", "Test"]
+git-tree-sha1 = "678106e8c300595a5643dbbca624e39bcb200cad"
+uuid = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
+version = "0.2.2"
+
+[[InteractiveUtils]]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+
+[[IterativeEigensolvers]]
+uuid = "de555fa4-b82f-55e7-8b71-53f60bbc027d"
+
+[[LibGit2]]
+uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+
+[[Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[[LinearAlgebra]]
+uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+
+[[Markdown]]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+
+[[Mmap]]
+uuid = "a63ad114-7e13-5084-954f-fe012c677804"
+
+[[Pkg]]
+uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+
+[[Polynomials]]
+deps = ["Compat"]
+git-tree-sha1 = "4c709222e10c370030cb417055bd69564fa089fe"
+uuid = "f27b6e38-b328-58d1-80ce-0feddd5e7a45"
+version = "0.3.0"
+
+[[Printf]]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+
+[[REPL]]
+uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+
+[[Random]]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[Reexport]]
+git-tree-sha1 = "caba582b2e9ef39b9cfff911aa13c5ca1b9a9896"
+uuid = "189a3867-3050-52da-a836-e630ba90ab69"
+version = "0.1.0"
+
+[[SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+
+[[Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[[SharedArrays]]
+uuid = "1a1011a3-84de-559e-8e89-a11a2f7dc383"
+
+[[Sockets]]
+uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+
+[[SparseArrays]]
+uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+
+[[SpecialFunctions]]
+deps = ["BinDeps", "Compat", "Libdl"]
+git-tree-sha1 = "a674e75798a737de67d6860b29a9e56a13d7639f"
+uuid = "276daf66-3868-5448-9aa4-cd146d93841b"
+version = "0.4.0"
+
+[[SuiteSparse]]
+uuid = "4607b0f0-06f3-5cda-b6b1-a6196a1729e9"
+
+[[Test]]
+uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[[URIParser]]
+deps = ["Compat", "Unicode"]
+git-tree-sha1 = "0f9c5e2d14e03fbd00696f9394e288bdd5adacbc"
+uuid = "30578b45-9adc-5946-b283-645ec420af67"
+version = "0.3.1"
+
+[[UUIDs]]
+uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
+[[Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"

--- a/Project.toml
+++ b/Project.toml
@@ -1,5 +1,6 @@
 name = "AutoGrad"
 version = "0.1.0"
+uuid ="87f375c9-9a48-40e3-9860-abb945b7e0cf"
 
 [deps]
 DSP = "717857b8-e6f2-59f4-9121-6e50c889abd2"

--- a/Project.toml
+++ b/Project.toml
@@ -3,6 +3,8 @@ uuid = "87f375c9-9a48-40e3-9860-abb945b7e0cf"
 version = "0.1.0"
 
 [deps]
+Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 DSP = "717857b8-e6f2-59f4-9121-6e50c889abd2"
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,7 @@
+name = "AutoGrad"
+version = "0.1.0"
+
+[deps]
+DSP = "717857b8-e6f2-59f4-9121-6e50c889abd2"
+FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
+SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AutoGrad"
+uuid = "87f375c9-9a48-40e3-9860-abb945b7e0cf"
 version = "0.1.0"
-uuid ="87f375c9-9a48-40e3-9860-abb945b7e0cf"
 
 [deps]
 DSP = "717857b8-e6f2-59f4-9121-6e50c889abd2"

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
 julia 0.6
 FFTW
 DSP
-Compat
+Compat 0.63

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,4 @@
 julia 0.6
+FFTW
+DSP
+Compat

--- a/src/AutoGrad.jl
+++ b/src/AutoGrad.jl
@@ -1,7 +1,7 @@
 __precompile__()
 module AutoGrad
 
-using Compat, Compat.Pkg, Compat.LinearAlgebra
+using Compat, Compat.Pkg, Compat.LinearAlgebra, Statistics
 
 # To see debug output of AutoGrad internals, set DBGFLAGS to
 # non-zero. Each bit of DBGFLAGS can be used to show a subset of dbg

--- a/src/base/abstractarraymath.jl
+++ b/src/base/abstractarraymath.jl
@@ -1,6 +1,6 @@
 # isinteger
 # isreal
-# ctranspose
+# adjoint
 # transpose
 # vec
 @primitive vec(x),dy reshape(dy,size(x))

--- a/src/base/arraymath.jl
+++ b/src/base/arraymath.jl
@@ -30,15 +30,16 @@
 # rot180
 # transpose!: Overwriting
 # transposeblock!: Not exported
-# ctranspose!: Overwriting
+# adjoint!: Overwriting
 # ctransposeblock!: Not exported
 # ccopy!: Not exported
 # transpose
 @primitive transpose(x),dy  transpose(dy)
 addtest(:transpose,rand(2,2))
-# ctranspose
-@primitive ctranspose(x),dy ctranspose(dy)
-addtest(:ctranspose,rand(2,2))
+# adjoint
+import Compat.adjoint
+@primitive adjoint(x),dy adjoint(dy)
+addtest(:adjoint,rand(2,2))
 # _cumsum_type: Not exported
 # cumsum
 # cumsum!

--- a/src/base/broadcast.jl
+++ b/src/base/broadcast.jl
@@ -43,7 +43,7 @@ function dxndx(x1,x2,dy)
     elseif x2==2
         2x1.*dy
     else
-        dy.*x2.*x1.^(x2-1)
+        dy.*x2.*x1.^(x2.-1)
     end
 end
 

--- a/src/base/deprecated/dict.jl
+++ b/src/base/deprecated/dict.jl
@@ -30,8 +30,8 @@
 # getindex: interfaces.jl
 # setindex!: overwriting
 # push!: overwriting
-# ObjectIdDict
-# similar: interfaces.jl
+# IdDict
+# empty: interfaces.jl
 # get: TODO
 # pop!: overwriting
 # delete!: overwriting

--- a/src/base/deprecated/tuple.jl
+++ b/src/base/deprecated/tuple.jl
@@ -1,5 +1,5 @@
 # length: interfaces.jl
-# endof: interfaces.jl
+# lastindex: interfaces.jl
 # size: interfaces.jl
 # getindex: interfaces.jl
 # start: interfaces.jl

--- a/src/base/float.jl
+++ b/src/base/float.jl
@@ -9,9 +9,10 @@ float1zero = [
 ]
 for f in float1zero
     @eval @zerograd $f(x)
-    bf = broadcast_func(f)
-    if bf != f
-        @eval @zerograd $bf(x)
+    let bf = broadcast_func(f)
+        if bf != f
+            @eval @zerograd $bf(x)
+        end
     end
 end
 
@@ -21,9 +22,10 @@ float2zero = [
 ]
 for f in float2zero
     @eval @zerograd $f(x1,x2)
-    bf = broadcast_func(f)
-    if bf != f
-        @eval @zerograd $bf(x1,x2)
+    let bf = broadcast_func(f)
+        if bf != f
+            @eval @zerograd $bf(x1,x2)
+        end
     end
 end
 
@@ -36,11 +38,12 @@ float1arg = [
 for (f,g) in float1arg
     @eval @primitive $f(x),dy,y $g
     # The broadcasting versions of unary versions are not defined in broadcast.jl
-    bf = broadcast_func(f)
-    if bf != f
-        @eval @primitive $bf(x),dy,y $g
+    let bf = broadcast_func(f)
+        if bf != f
+            @eval @primitive $bf(x),dy,y $g
+        end
+        addtest1(f,(-Inf,Inf))
     end
-    addtest1(f,(-Inf,Inf))
 end
 
 float2arg = [

--- a/src/base/math.jl
+++ b/src/base/math.jl
@@ -6,28 +6,29 @@
 # inputs.  The last part gives the range for generating test cases.
 
 math1arg = [
-(:cbrt, :(1./(3.*abs2.(y))), (-Inf,Inf)),
+(:cbrt, :(1 ./ (3 .* abs2.(y))), (-Inf,Inf)),
 (:deg2rad, :(pi/180), (-Inf,Inf)),
 (:exp, :y, (-Inf,Inf)),
-(:exp10, :(y.*log(10)), (-Inf,Inf)),
-(:exp2, :(y.*log(2)), (-Inf,Inf)),
-(:expm1, :(1+y), (-Inf,Inf)),
-(:log, :(1./x), (0,Inf)),
-(:log10, :(1./(log(10).*x)), (0,Inf)),
-(:log1p, :(1./(1+x)), (-1,Inf)),
-(:log2, :(1./(log(2).*x)), (0,Inf)),
+(:exp10, :(y .* log(10)), (-Inf,Inf)),
+(:exp2, :(y .* log(2)), (-Inf,Inf)),
+(:expm1, :(1 .+ y), (-Inf,Inf)),
+(:log, :(1 ./ x), (0,Inf)),
+(:log10, :(1 ./ (log(10) .* x)), (0,Inf)),
+(:log1p, :(1 ./ (1 .+ x)), (-1,Inf)),
+(:log2, :(1 ./ (log(2).*x)), (0,Inf)),
 (:rad2deg, :(180/pi), (-Inf,Inf)),
-(:significand, :(0.5.^exponent.(x)), (-Inf,Inf)),
-(:sqrt, :(1./(2.*y)), (0,Inf)),
+(:significand, :(0.5 .^ exponent.(x)), (-Inf,Inf)),
+(:sqrt, :(1 ./ (2 .* y)), (0,Inf)),
 ]
 
 for (f,g,r) in math1arg
-    bf = broadcast_func(f)
-    @eval @primitive $f(x),dy,y  (dy.*($g))
-    if f != bf
-        @eval @primitive $bf(x),dy,y  (dy.*($g))
+    let bf = broadcast_func(f)
+        @eval @primitive $f(x),dy,y  (dy .* ($g))
+        if f != bf
+            @eval @primitive $bf(x),dy,y  (dy .* ($g))
+        end
+        addtest1(f,r)
     end
-    addtest1(f,r)
 end
 
 
@@ -44,27 +45,28 @@ end
 # gradient definitions.
 
 math2arg = [
-(:atan2, quote x2./(abs2.(x1)+abs2.(x2)) end, quote -x1./(abs2.(x1)+abs2.(x2)) end),
-(:hypot, quote x1./y end, quote x2./y end),
+(:atan2, quote x2 ./ (abs2.(x1) .+ abs2.(x2)) end, quote -x1 ./ (abs2.(x1) .+ abs2.(x2)) end),
+(:hypot, quote x1 ./ y end, quote x2 ./ y end),
 (:max, quote y.==x1 end, quote y.==x2 end),
 (:min, quote y.==x1 end, quote y.==x2 end),
-(:log, quote -log.(x2)./(x1.*abs2.(log.(x1))) end, quote 1./(x2.*log.(x1)) end),
+(:log, quote -log.(x2) ./ (x1.*abs2.(log.(x1))) end, quote 1 ./ (x2.*log.(x1)) end),
 ]
 
 # The 2-arg log supports positive args for reals.
 log(x1::Irrational{:e},x2::Rec)=log(float(x1),x2) # to avoid clash with irrationals.jl:131.
 
 for (f,g1,g2) in math2arg
-    bf = broadcast_func(f)
-    @eval @primitive $f(x1,x2),dy,y  unbroadcast(x1,dy.*($g1))  unbroadcast(x2,dy.*($g2))
-    if f != bf
-        @eval @primitive $bf(x1,x2),dy,y  unbroadcast(x1,dy.*($g1))  unbroadcast(x2,dy.*($g2))
+    let bf = broadcast_func(f)
+        @eval @primitive $f(x1,x2),dy,y  unbroadcast(x1,dy .* ($g1))  unbroadcast(x2,dy .* ($g2))
+        if f != bf
+            @eval @primitive $bf(x1,x2),dy,y  unbroadcast(x1,dy .* ($g1))  unbroadcast(x2,dy .* ($g2))
+        end
+        addtest2(f, (f==:log ? (0,Inf) : (-Inf,Inf)))
     end
-    addtest2(f, (f==:log ? (0,Inf) : (-Inf,Inf)))
 end
 
 # ^ only supports (N>=0,N), arrays not supported in math.jl, only M^N in linalg/dense.jl (TODO)
-(^){T<:AbstractFloat}(x1::Rec{T},x2::Integer)=(^)(x1,convert(eltype(x1.value),x2)) # to avoid clash with intfuncs:199
+(^)(x1::Rec{T},x2::Integer) where {T<:AbstractFloat}=(^)(x1,convert(eltype(x1.value),x2)) # to avoid clash with intfuncs:199
 (^)(x1::Broadcasted,x2::Integer)=(^)(x1,convert(eltype(x1.value),x2)) # to avoid clash with intfuncs:199
 @primitive (^)(x1::Number,x2::Number),dy,y  (dy*x2*x1^(x2-1))  (dy*y*log.(x1))
 addtestN(:^, randin((0,Inf)), randin((-Inf,Inf)))
@@ -75,37 +77,41 @@ addtestN(:^, rand(1:10), rand(1:5))
 
 # clamp(x,lo,hi) clamps x between lo and hi
 @primitive clamp(x,lo,hi),dy,y  unbroadcast(x,dy.*(lo .<= x .<= hi))
-bf = broadcast_func(:clamp)
-if bf != :clamp
-    @eval @primitive $bf(x,d...),dy,y  unbroadcast(x,dy.*(d[1] .<= x .<= d[2]))
+let bf = broadcast_func(:clamp)
+    if bf != :clamp
+        @eval @primitive $bf(x,d...),dy,y  unbroadcast(x,dy.*(d[1] .<= x .<= d[2]))
+    end
+    addtest(:clamp, randn(), -1., 1.)
+    addtest(bf, randn(10), -1., 1.)
+    broadcast_func(:&)  # need this for (lo .<= x .<= hi)
 end
-addtest(:clamp, randn(), -1., 1.)
-addtest(bf, randn(10), -1., 1.)
-broadcast_func(:&)  # need this for (lo .<= x .<= hi)
 
 # ldexp(x,n) computes x*2^n with x real, n integer
 @primitive ldexp(x,n...),dy  (dy*(2.0^n[1]))
 addtest(:ldexp, randn(), rand(-2:2))
-bf = broadcast_func(:ldexp)
-if bf != :ldexp
-    @eval @primitive $bf(x,n...),dy  (dy.*(2.0^n[1]))    
-    addtest(bf, randn(2), rand(-2:2))
+let bf = broadcast_func(:ldexp)
+    if bf != :ldexp
+        @eval @primitive $bf(x,n...),dy  (dy.*(2.0^n[1]))    
+        addtest(bf, randn(2), rand(-2:2))
+    end
 end
 
 # mod2pi(x) returns modulus after division by 2pi for x real.
 @primitive mod2pi(x),dy dy
 addtest(:mod2pi, 100randn())
-bf = broadcast_func(:mod2pi)
-if bf != :mod2pi
-    @eval @primitive $bf(x),dy dy
-    addtest(bf, 100randn(2))
+let bf = broadcast_func(:mod2pi)
+    if bf != :mod2pi
+        @eval @primitive $bf(x),dy dy
+        addtest(bf, 100randn(2))
+    end
 end
 
 # zerograd functions
-bf = broadcast_func(:exponent)
-@zerograd exponent(x)
-if bf != :exponent
-    @eval @zerograd $bf(x)
+let bf = broadcast_func(:exponent)
+    @zerograd exponent(x)
+    if bf != :exponent
+        @eval @zerograd $bf(x)
+    end
 end
 
 # Other functions defined in julia/base/math.jl

--- a/src/base/number.jl
+++ b/src/base/number.jl
@@ -4,12 +4,13 @@ number1arg = [
 ]
 
 for (f,g) in number1arg
-    bf = broadcast_func(f)
-    @eval @primitive $f(x),dy,y  (dy.*($g))
-    if bf != f
-        @eval @primitive $bf(x),dy,y  (dy.*($g))
+    let bf = broadcast_func(f)
+        @eval @primitive $f(x),dy,y  (dy.*($g))
+        if bf != f
+            @eval @primitive $bf(x),dy,y  (dy.*($g))
+        end
+        addtest1(f,(-Inf,Inf))
     end
-    addtest1(f,(-Inf,Inf))
 end
 
 number1zero = [
@@ -18,10 +19,11 @@ number1zero = [
 :signbit,
 ]
 for f in number1zero
-    bf = broadcast_func(f)
-    @eval @zerograd $f(x)
-    if bf != f
-        @eval @zerograd $bf(x)
+    let bf = broadcast_func(f)
+        @eval @zerograd $f(x)
+        if bf != f
+            @eval @zerograd $bf(x)
+        end
     end
 end
 
@@ -30,17 +32,17 @@ end
 # eltype: interfaces.jl
 # ndims: interfaces.jl
 # length: interfaces.jl
-# endof: interfaces.jl
+# lastindex: interfaces.jl
 # getindex: interfaces.jl
 # unsafe_getindex: Not exported
 # first: compound using start/next
-# last: compound using getindex/endof
+# last: compound using getindex/lastindex
 # divrem
 # fldmod
 # copysign
 # conj
 # transpose
-# ctranspose
+# adjoint
 # inv
 # angle
 # widemul

--- a/src/base/reduce.jl
+++ b/src/base/reduce.jl
@@ -15,8 +15,7 @@ minabs_(x...; kargs...)=minimum(abs,x...; kargs...)
 maxabs_(x...; kargs...)=maximum(abs,x...; kargs...)
 
 _ones(x::Rec{T}) where T<:Number = one(T) #fix #56
-_ones(x::Rec{Array{T}}) where T<:Number = fill(one(T), size(x,value))
-_ones(x::Rec) = ones(x)
+_ones(x::Rec) = fill(1.0, size(x.value))
 
 for (f,g) in reduce1arg
     @eval @primitive  $f(x,i...; kargs...),dy,y   (dy.*($g))

--- a/src/base/reduce.jl
+++ b/src/base/reduce.jl
@@ -16,6 +16,7 @@ maxabs_(x...; kargs...)=maximum(abs,x...; kargs...)
 
 _ones(x::Rec{T}) where T<:Number = one(T) #fix #56
 _ones(x::Rec) = fill(1.0, size(x.value))
+# _ones(x::Rec) = ones(x)
 
 for (f,g) in reduce1arg
     @eval @primitive  $f(x,i...; kargs...),dy,y   (dy.*($g))

--- a/src/base/reduce.jl
+++ b/src/base/reduce.jl
@@ -1,3 +1,5 @@
+import Statistics.mean
+
 reduce1arg = [
 (:sum,      :(_ones(x))),
 (:sumabs_,  :(sign.(x))),

--- a/src/base/statistics.jl
+++ b/src/base/statistics.jl
@@ -1,20 +1,37 @@
-function var(x::Rec, dims; mean=Base.mean(x, dims), corrected=true)
-    s = sum(abs2, x .- mean, dims)
-    a = length(x) ÷ length(s) 
-    corrected ? s ./ (a-1) : s ./ a  
-end
+if VERSION < v"0.7.0-DEV.4064"
+    function var(x::Rec, dims; mean=Base.mean(x, dims), corrected=true)
+        s = sum(abs2, x .- mean, dims)
+        a = length(x) ÷ length(s) 
+        corrected ? s ./ (a-1) : s ./ a  
+    end
 
-function var(x::Rec; mean=Base.mean(x), corrected=true)
-    s = sum(abs2, x .- mean)
-    a = length(x) ÷ length(s) 
-    corrected ? s / (a-1) : s / a  
+    function var(x::Rec; mean=Base.mean(x), corrected=true)
+        s = sum(abs2, x .- mean)
+        a = length(x) ÷ length(s) 
+        corrected ? s / (a-1) : s / a  
+    end
+else
+    function var(x::Rec; dims = :, mean=Base.mean(x, dims = dims), corrected=true)
+        s = sum(abs2, x .- mean, dims = dims)
+        a = length(x) ÷ length(s) 
+        corrected ? s ./ (a-1) : s ./ a  
+    end
 end
 
 addtest(:var, rand(2,3))
-addtest(:var, rand(2,3), 1)
-addtest(:var, rand(2,3), (1,2))
-
-std(x::Rec, args...; kws...) = sqrt.(var(x, args...; kws...))
 addtest(:std, rand(2,3))
-addtest(:std, rand(2,3), 1)
-addtest(:std, rand(2,3), (1,2))
+
+if VERSION < v"0.7.0-DEV.4064"
+    addtest(:var, rand(2,3), 1)
+    addtest(:std, rand(2,3), 1)
+    addtest(:std, rand(2,3), (1,2))
+    addtest(:var, rand(2,3), (1,2))
+    std(x::Rec, args...; kws...) = sqrt.(var(x, args...; kws...))
+else
+    addtest(:var, rand(2,3), dims = 1)
+    addtest(:std, rand(2,3), dims = 1)
+    addtest(:std, rand(2,3), dims = (1,2))
+    addtest(:var, rand(2,3), dims = (1,2))
+    std(x::Rec; kws...) = sqrt.(var(x; kws...))
+end
+

--- a/src/gradcheck.jl
+++ b/src/gradcheck.jl
@@ -67,7 +67,7 @@ end
 
 function gc_index(w, d, i, f, w0, x...; o...)
     di = nothing
-    try; di = d[i]; end
+    try; di = d[i]; catch end
     if isa(w[i], Number)
         gc_array(w, d, f, w0, x...; icheck=i, o...)
     elseif isbits(eltype(w[i]))

--- a/src/gradcheck.jl
+++ b/src/gradcheck.jl
@@ -142,7 +142,7 @@ function gc_scalar(f)
             # srand(r,1)
             # a = oftype(v, rand(r, size(v)))
             # return sum(y .* a)
-            if isa(getval(y), Associative)
+            if isa(getval(y), AbstractDict)
                 return sumvalues(y)
             else
                 return sum(y)  # TODO: revert this back to y.*a once julia6 compat issues resolved?
@@ -158,19 +158,27 @@ end
 
 ### Testing Utilities:
 
-if !isdefined(:addtest)
-let tests=[]
+struct KnetTest
+    f::Symbol
+    args::Tuple
+    kargs::Array
+end
+
+if !isdefined(@__MODULE__, :addtest)
+let tests=KnetTest[]
     global addtest,runtests,alltests
     alltests()=tests
-    addtest(t...)=push!(tests,t)
-    function runtests(a=tests)
-        for fx in a
+    function addtest(f,t...; kargs...)
+        push!(tests,KnetTest(f,t,collect(kargs)))
+    end
+    function runtests(a::Array{KnetTest} = tests)
+        for test in a
             try 
                 # tx = fixtest(fx...)
                 # check_grads(tx...; fname=fx[1]) || throw(:fail)
                 f = eval(AutoGrad,fx[1])
                 x = fx[2:end]
-                gradcheck(f,x...) || throw(:fail)
+                gradcheck(test.f,test.args...; test.kargs...) || throw(:fail)
             catch e
                 warn((fx...,"$e"))
             end
@@ -206,22 +214,22 @@ function randin(range, dims...; eps=0.01)
         rand(range, dims...)
     elseif range==(-Inf,Inf)
         r = randn(dims...)
-        sign.(r)*eps + r
+        sign.(r)*eps .+ r
     elseif range==(0,Inf)
-        eps-log.(rand(dims...))
+        eps .- log.(rand(dims...))
     elseif range==(1,Inf)
-        eps+1-log.(rand(dims...))
+        eps .+ 1 .- log.(rand(dims...))
     elseif range==(-1,Inf)
-        eps-1-log.(rand(dims...))
+        eps .- 1 .- log.(rand(dims...))
     elseif range==(-1,1)
-        (1-eps)*(2rand(dims...)-1)
+        (1 .- eps) .* (2 .* rand(dims...) .- 1)
     elseif range==(0,1)
-        eps+(1-2eps)*rand(dims...)
+        eps .+ (1 .- 2eps) .* rand(dims...)
     elseif range==(0,2)
-        eps+2*(1-eps)*rand(dims...)
+        eps .+2 .* (1 .- eps) .* rand(dims...)
     elseif range==(-Inf,-1,1,Inf)
         x = sec.(randn(dims...))
-        sign.(x)*eps + x
+        sign.(x) .* eps .+ x
     else
         error("Unknown range $range")
     end
@@ -253,7 +261,7 @@ function nd(f, args...; eps=EPS)
 end
 
 unary_nd(f, x::Tuple, eps)         = ntuple(i->unary_nd(indexed_function(f, x, i), x[i], eps), length(x))
-unary_nd(f, x::Associative, eps)   = (a=similar(x); for(k,v) in x; a[k] = unary_nd(indexed_function(f, x, k), v, eps); end; a)
+unary_nd(f, x::AbstractDict, eps)   = (a=(VERSION < v"0.7.0-DEV.2723" ? similar(x) : empty(x)); for(k,v) in x; a[k] = unary_nd(indexed_function(f, x, k), v, eps); end; a)
 unary_nd(f, x::AbstractArray, eps) = reshape(eltype(x)[unary_nd(indexed_function(f, x, i), v, eps) for (i,v) in enumerate(x)], size(x))
 unary_nd(f, x::Complex, eps)       = ((f(x + eps/2) - f(x - eps/2)) / eps - im*(f(x + im*eps/2) - f(x - im*eps/2)) / eps)
 unary_nd(f, x::Real, eps)          = ((f(x + eps/2) - f(x - eps/2)) / eps)
@@ -272,18 +280,18 @@ end
 
 # isequivalent uses isapprox for Number and AbstractArray{T<:Number}
 isequivalent(x::Number,y::Number; o...)=isapprox(x,y;o...)
-isequivalent{T<:Number,S<:Number}(x::AbstractArray{T},y::AbstractArray{S}; o...)=(size(x)==size(y) && isapprox(x,y;o...))
+isequivalent(x::AbstractArray{T},y::AbstractArray{S}; o...) where {T<:Number,S<:Number}=(size(x)==size(y) && isapprox(x,y;o...))
 
-# isequivalent extends to Tuple, Associative, and other Arrays, comparing elementwise
+# isequivalent extends to Tuple, AbstractDict, and other Arrays, comparing elementwise
 isequivalent(x::Tuple, y::Tuple; o...)=(length(x)==length(y) && all(i->isequivalent(x[i],y[i];o...), 1:length(x)))
 isequivalent(x::AbstractArray, y::AbstractArray; o...)=(length(x)==length(y) && all(i->isequivalent(x[i],y[i];o...), 1:length(x)))
-isequivalent(x::Associative, y::Associative; o...)=all(k->isequivalent(get(x,k,nothing),get(y,k,nothing);o...), unique([keys(x)...,keys(y)...]))
+isequivalent(x::AbstractDict, y::AbstractDict; o...)=all(k->isequivalent(get(x,k,nothing),get(y,k,nothing);o...), unique([keys(x)...,keys(y)...]))
 
 # isequivalent treats `nothing` as equivalent to zero or zero array.
-isequivalent(x::Number,z::Void; o...)=isequivalent(z,x;o...)
-isequivalent{T<:Number}(x::AbstractArray{T},z::Void; o...)=isequivalent(z,x;o...)
-isequivalent(z::Void,x::Number; o...)=isapprox(zero(x),x;o...)
-isequivalent{T<:Number}(z::Void,x::AbstractArray{T}; rtol::Real=Base.rtoldefault(T), atol::Real=0, norm::Function=vecnorm) = (norm(x) <= atol/(1-rtol)) # Modified from: linalg/generic.jl:522
+isequivalent(x::Number,z::Nothing; o...)=isequivalent(z,x;o...)
+isequivalent(x::AbstractArray{T},z::Nothing; o...) where {T<:Number}=isequivalent(z,x;o...)
+isequivalent(z::Nothing,x::Number; o...)=isapprox(zero(x),x;o...)
+isequivalent(z::Nothing,x::AbstractArray{T}; rtol::Real=Base.rtoldefault(T), atol::Real=0, norm::Function=vecnorm) where {T<:Number} = (norm(x) <= atol/(1-rtol)) # Modified from: linalg/generic.jl:522
 
 function fixtest(f, x...)
     f = eval(f)
@@ -302,7 +310,7 @@ function fixtest(f, x...)
             if isa(e,MethodError) && e.f === f && e.args[1] === Grad{i}
                 continue        # warn("No grad $i for $f: $e")
             else
-                error("Error during $f$((gargs...)): $e")
+                error("Error during $f$((gargs...,)): $e")
             end
         end
         g === nothing && continue # zero grads

--- a/src/interfaces.jl
+++ b/src/interfaces.jl
@@ -1,7 +1,7 @@
 # Here we will define iteration (start,done,next) and indexing
-# (getindex,setindex!,endof) interfaces for generic Rec types.
+# (getindex,setindex!,endof/lastindex) interfaces for generic Rec types.
 
-# Julia handles access to AbstractArray, Associative, and Tuple
+# Julia handles access to AbstractArray, AbstractDict, and Tuple
 # subtypes using getindex:
 
 # getindex(obj, key...) => value
@@ -14,7 +14,7 @@ setindex!(x::Rec,v,i...)=error("Overwriting operations currently not supported."
 # We handle the containers by overloading getindex:
 
 @primitive  getindex(x,i...),dxi,xi  ungetindex(x,dxi,i)
-getindex{T<:Grad}(::Type{T},o...)=nothing # Only the first arg has gradient
+getindex(::Type{T},o...) where {T<:Grad}=nothing # Only the first arg has gradient
 
 # For efficiency we use the following sparse container
 # This object represents what you would get with
@@ -26,7 +26,7 @@ getindex{T<:Grad}(::Type{T},o...)=nothing # Only the first arg has gradient
 # TODO: implement KnetArray version of addindex!
 # TODO: figure out julia4 problem with Array{CartesianIndex}
 
-immutable UngetIndex; container; value; index; end
+struct UngetIndex; container; value; index; end
 
 # Gradient of getindex: If xi=getindex(x,i...) and we receive dxi,
 # ungetindex creates dx representing zeros similar to x, with only
@@ -52,8 +52,8 @@ ungetindex(x::Rec,dxi::Rec,i)=ungetindex(getval(x),dxi,getval(i))
 ungetindex(x::Rec,dxi,i)=ungetindex(getval(x),dxi,getval(i))
 ungetindex(::Type{Grad{2}},ddx,dx,x,dxi,i)=getindex(ddx,getval(i)...)
 ungetindex(::Type{Grad{2}},ddx::Rec,dx,x,dxi,i)=getindex(ddx,getval(i)...)
-ungetindex{T<:Grad}(::Type{T},o...)=nothing
-ungetindex{T<:Grad}(::Type{T},ddx::Rec,o...)=nothing
+ungetindex(::Type{T},o...) where {T<:Grad}=nothing
+ungetindex(::Type{T},ddx::Rec,o...) where {T<:Grad}=nothing
 
 # gradcheck works with the first arg, we need to check ungetindex grad for its second arg
 ungetindex2(value, container, index)=ungetindex(container, value, index)
@@ -69,7 +69,7 @@ addtest(:ungetindex2, rand(2), rand(3,3), (1:2,3))
 # design is to not use UngetIndex for outgrad lest it gets exposed to
 # the user. May rethink this from an efficiency perspective.
 
-function sum_outgrads(a::Void,b::UngetIndex)
+function sum_outgrads(a::Nothing,b::UngetIndex)
     full(b) # TODO: do we need full here? consider keeping UngetIndex as an accumulator.
 end
 
@@ -85,7 +85,7 @@ end
 
 # Dict has no multiple/repeated index problem, so simple setindex should work.
 # If we change UngetIndex to have multiple indices, we need to be careful here.
-function sum_outgrads(a::Associative,b::UngetIndex)
+function sum_outgrads(a::AbstractDict,b::UngetIndex)
     setindex!(a,sum_outgrads(get(a,b.index...,nothing),b.value),b.index...)
 end
 
@@ -104,7 +104,7 @@ using Base.Cartesian
     N = length(I)
     quote
         ### We need to handle bool arrays and colons here
-        @nexprs $N d->(I_d = I[d]; if isa(I_d,AbstractArray{Bool}); I_d=find(I_d); elseif isa(I_d,Colon); I_d=1:size(A,d); end)
+        @nexprs $N d->(I_d = I[d]; if isa(I_d,AbstractArray{Bool}); I_d=findall(I_d); elseif isa(I_d,Colon); I_d=1:size(A,d); end)
         ### Using nothing for zero array fails this check
         # idxlens = @ncall $N index_lengths A I
         # @ncall $N setindex_shape_check X (d->idxlens[d])
@@ -139,7 +139,7 @@ sum_outgrads_array(A::AbstractArray, X, I::CartesianIndex)=sum_outgrads_single(A
 sum_outgrads_array(A::AbstractArray, X, I::Real)=sum_outgrads_single(A,X,I)
 sum_outgrads_array(A::AbstractArray, X, I::Colon)=sum_outgrads_single(A,X,I)
 sum_outgrads_array(A::AbstractArray, X, I::AbstractArray{Bool})=sum_outgrads_single(A,X,I)
-sum_outgrads_array(A::AbstractArray, X, I::Range)=sum_outgrads_single(A,X,I)
+sum_outgrads_array(A::AbstractArray, X, I::AbstractRange)=sum_outgrads_single(A,X,I)
 function sum_outgrads_single(A::AbstractArray, X, I)
     v = sum_outgrads(getindex(A,I), X)
     setindex!(A, v, I)
@@ -155,7 +155,7 @@ function sum_outgrads(a::UngetIndex,b::UngetIndex)
 end
 
 # This comes up if people use getindex on a number:
-function sum_outgrads{T<:Number}(a::T, b::UngetIndex)
+function sum_outgrads(a::T, b::UngetIndex) where {T<:Number}
     if !(b.index == (1,) && isa(b.value,T))
         throw(ArgumentError("sum_outgrads($a,$b)"))
     end
@@ -165,24 +165,25 @@ end
 # These should be never needed as long as we do not use UngetIndex as an accumulator on the LHS.
 # sum_outgrads(a::Rec,b::UngetIndex)=error((:sum,a,b))
 # sum_outgrads(a::UngetIndex,b::Rec)=error((:sum,a,b))
-# sum_outgrads(a::UngetIndex,b::Void)=error((:sum,a,b))
+# sum_outgrads(a::UngetIndex,b::Nothing)=error((:sum,a,b))
 # sum_outgrads(a::UngetIndex,b)=error((:sum,a,Any))
 
 sum(b::UngetIndex)=sum(b.value)
 getindex(b::UngetIndex,i...)=getindex(full(b),i...) # TODO: solve without full(b)?
-zeros(b::UngetIndex)=zeros(b.container)             # TODO: solve without b.container?
+zeros(b::UngetIndex)=fill(0.0, size(b.container))             # TODO: solve without b.container?
 ones(b::UngetIndex)=ones(b.container)
+size(b::UngetIndex)=size(b.container)
 length(b::UngetIndex)=length(b.container)
 full(b::UngetIndex)=sum_outgrads(zeroslike(b.container), b)
 
-zeroslike{T<:Number}(a::AbstractArray{T})=zeros(a)  # TODO: can this be nothing or an empty UngetIndex?
-zeroslike(a::AbstractArray)=fill!(Array{Any}(size(a)),nothing) # TODO: can this be nothing or an empty UngetIndex?
-zeroslike(a::Associative)=similar(a)
+zeroslike(a::AbstractArray{T}) where {T<:Number}=zero(a)  # TODO: can this be nothing or an empty UngetIndex?
+zeroslike(a::AbstractArray)=fill!(Array{Any}(undef,size(a)),nothing) # TODO: can this be nothing or an empty UngetIndex?
+zeroslike(a::AbstractDict)=(VERSION < v"0.7.0-DEV.2723" ? similar(a) : empty(a))
 zeroslike(a::Tuple)=ntuple(i->nothing, length(a))
-zeroslike(o::UngetIndex)=zeros(o) # TODO: can this be nothing or empty UngetIndex?
-zeroslike{T<:Number}(a::T)=T(0)   # This comes up if people use getindex on a single number
+zeroslike(o::UngetIndex)=fill(0.0, size(o)) # TODO: can this be nothing or empty UngetIndex?
+zeroslike(a::T) where {T<:Number}=T(0)   # This comes up if people use getindex on a single number
 
-_dbg(x::UngetIndex)="U$(id2(x))_$(_dbg(x.container))_$(_dbg(x.value))_$((x.index...))"
+_dbg(x::UngetIndex)="U$(id2(x))_$(_dbg(x.container))_$(_dbg(x.value))_$((x.index...,))"
 Base.show(io::IO, n::UngetIndex)= print(io, _dbg(n))
 
 ### ITERATION
@@ -202,10 +203,10 @@ done(a::Rec,i)=done(a.value,i)
 # Specific types need to define their own next methods for Recs:
 
 next(a::Rec,i)=throw(MethodError(next,(a,i)))
-next{T<:Array}(a::Rec{T},i) = (a[i],i+1)
-next{T<:Tuple}(a::Rec{T},i) = (a[i],i+1)
-next{T<:Number}(a::Rec{T},i) = (a,true)
-next{T<:Associative}(a::Rec{T},i) = (((k,v),j)=next(a.value,i);(k=>a[k],j))
+next(a::Rec{T},i) where {T<:Array} = (a[i],i+1)
+next(a::Rec{T},i) where {T<:Tuple} = (a[i],i+1)
+next(a::Rec{T},i) where {T<:Number} = (a,true)
+next(a::Rec{T},i) where {T<:AbstractDict} = (((k,v),j)=next(a.value,i);(k=>a[k],j))
 # This needs more work:
 # next{T<:Base.RecIterator}(a::Rec{T},i) = (d=a.value.dict; (d.vals[i], skip_deleted(d,i+1)))
 
@@ -214,16 +215,17 @@ next{T<:Associative}(a::Rec{T},i) = (((k,v),j)=next(a.value,i);(k=>a[k],j))
 
 interfaces1arg = [
 :eltype,
-:endof,
+(VERSION < v"0.7.0-DEV.3579" ? :endof : :lastindex),
 :isempty,
 :length,
 :ndims,
 :one,
-:ones,
 :strides,
 :zero,
-:zeros,
 ]
+if VERSION < v"0.7.0-DEV.3579"
+    append!(interfaces1arg, [:ones, :zeros])
+end
 
 for _f in interfaces1arg
     @eval @zerograd $_f(x)
@@ -237,7 +239,7 @@ interfaces1arg_type = [
 ]
 
 for _f in interfaces1arg_type
-    @eval $_f{T}(::Type{Rec{T}}) = $_f(T)
+    @eval $_f(::Type{Rec{T}}) where {T} = $_f(T)
 end
 
 interfacesNarg = [

--- a/src/linalg/matmul.jl
+++ b/src/linalg/matmul.jl
@@ -1,11 +1,18 @@
+_Ac_mul_B(A,B) = adjoint(A) * B
+_At_mul_B(A,B) = transpose(A) * B
+_A_mul_Bc(A,B) = A * adjoint(B)
+_A_mul_Bt(A,B) = A * transpose(B)
+_Ac_mul_Bc(A,B) = adjoint(A) * adjoint(B)
+_At_mul_Bt(A,B) = transpose(A) * transpose(B)
+
 matmul2arg = [
 (:*,         :(dy*x2'),    :(x1'*dy),    :(dy),   :(dy)),
-(:Ac_mul_B,  :(x2*dy'),    :(x1*dy),     :(dy'),  :(dy)),
-(:At_mul_B,  :(x2*dy.'),   :(x1*dy),     :(dy.'), :(dy)),
-(:A_mul_Bc,  :(dy*x2),     :(dy'*x1),    :(dy),   :(dy')),
-(:A_mul_Bt,  :(dy*x2),     :(dy.'*x1),   :(dy),   :(dy.')),
-(:Ac_mul_Bc, :(x2'*dy'),   :(dy'*x1'),   :(dy'),  :(dy')),
-(:At_mul_Bt, :(x2.'*dy.'), :(dy.'*x1.'), :(dy.'), :(dy.')),
+(:_Ac_mul_B,  :(x2*dy'),    :(x1*dy),     :(dy'),  :(dy)),
+(:_At_mul_B,  :(x2*transpose(dy)),   :(x1*dy),     :(transpose(dy)), :(dy)),
+(:_A_mul_Bc,  :(dy*x2),     :(dy'*x1),    :(dy),   :(dy')),
+(:_A_mul_Bt,  :(dy*x2),     :(transpose(dy)*x1),   :(dy),   :(transpose(dy))),
+(:_Ac_mul_Bc, :(x2'*dy'),   :(dy'*x1'),   :(dy'),  :(dy')),
+(:_At_mul_Bt, :(transpose(x2)*transpose(dy)), :(transpose(dy)*transpose(x1)), :(transpose(dy)), :(transpose(dy))),
 ]
 
 function addtest_matmul(f)
@@ -48,7 +55,7 @@ end
 # scale
 # vecdot
 @primitive dot(x1, x2),dy,y  dy*x2  dy*x1
-addtestN(:dot, rand(3,2), rand(3,2))
+addtestN(:dot, rand(3), rand(3))
 
 # Ac_mul_B
 # At_mul_B

--- a/src/special/bessel.jl
+++ b/src/special/bessel.jl
@@ -18,13 +18,14 @@ besselj2(x)=besselj(2,x)
 bessely2(x)=bessely(2,x)
 
 for (f,g,r) in bessel1arg
-    bf = broadcast_func(f)
-    @eval @primitive $f(x),dy,y  (dy.*($g))
-    if bf != f
-        @eval @primitive $bf(x),dy,y  (dy.*($g))
-    end
-    if !in(f, (:airyprime, :besselj2, :bessely2))
-        addtest1(f,r)
+    let bf = broadcast_func(f)
+        @eval @primitive $f(x),dy,y  (dy.*($g))
+        if bf != f
+            @eval @primitive $bf(x),dy,y  (dy.*($g))
+        end
+        if !in(f, (:airyprime, :besselj2, :bessely2))
+            addtest1(f,r)
+        end
     end
 end
 

--- a/src/special/erf.jl
+++ b/src/special/erf.jl
@@ -1,22 +1,23 @@
 convel(x,y) = convel(eltype(x), y)
-convel{T<:AbstractFloat}(::Type{T}, y) = convert(T, y)
-convel{T}(::Type{T}, y) = y
+convel(::Type{T}, y) where {T<:AbstractFloat} = convert(T, y)
+convel(::Type{T}, y) where {T} = y
 
 erf1arg = [
-(:erf, :(exp.(-abs2.(x))* convel(x,2/√π)), (-Inf,Inf)),     # \frac{2}{\sqrt{\pi}} \int_0^x e^{-t^2} dt
+(:erf, :(exp.(-abs2.(x))* convel(x,2/√π)), (-Inf,Inf)),      # \frac{2}{\sqrt{\pi}} \int_0^x e^{-t^2} dt
 (:erfc, :(-exp.(-abs2.(x)) * convel(x,2/√π)), (-Inf,Inf)),   # 1-erf(x)
-(:erfcx, :(2y.*x-convel(x,2/√π)), (-Inf,Inf)),           # erfc(x)*exp(x^2)
-(:erfi, :(exp.(abs2.(x))*convel(x,2/√π)), (-Inf,Inf)),     # -i*erf(ix)
-(:dawson, :(-2y.*x+1), (-Inf,Inf)),                  # \frac{\sqrt{\pi}}{2} e^{-x^2} erfi(x).
-(:erfinv, :(exp.(abs2.(y))*convel(x,√π/2)), (-1,1)),       # erf(erfinv(x)) = x
-(:erfcinv, :(-exp.(abs2.(y))*convel(x,√π/2)), (0,2)),      # erfc(erfcinv(x)) = x
+(:erfcx, :(2y.*x .- convel(x,2/√π)), (-Inf,Inf)),            # erfc(x)*exp(x^2)
+(:erfi, :(exp.(abs2.(x))*convel(x,2/√π)), (-Inf,Inf)),       # -i*erf(ix)
+(:dawson, :(-2y.*x .+ 1), (-Inf,Inf)),                       # \frac{\sqrt{\pi}}{2} e^{-x^2} erfi(x).
+(:erfinv, :(exp.(abs2.(y))*convel(x,√π/2)), (-1,1)),         # erf(erfinv(x)) = x
+(:erfcinv, :(-exp.(abs2.(y))*convel(x,√π/2)), (0,2)),        # erfc(erfcinv(x)) = x
 ]
 
 for (f,g,r) in erf1arg
-    bf = broadcast_func(f)
-    @eval @primitive $f(x),dy,y  (dy.*($g))
-    if bf != f
-        @eval @primitive $bf(x),dy,y  (dy.*($g))
+    let bf = broadcast_func(f)
+        @eval @primitive $f(x),dy,y  (dy.*($g))
+        if bf != f
+            @eval @primitive $bf(x),dy,y  (dy.*($g))
+        end
+        addtest1(f,r)
     end
-    addtest1(f,r)
 end

--- a/src/special/gamma.jl
+++ b/src/special/gamma.jl
@@ -1,10 +1,10 @@
 gamma1arg = [
-(:gamma, :(y.*digamma.(x)), (-Inf,Inf)),
-# (:lfact, :(sign.(y).*digamma.(x+1)), (-Inf,Inf)), # lfact only defined for integers
+(:gamma, :(y .* digamma.(x)), (-Inf,Inf)),
+# (:lfact, :(sign.(y) .* digamma.(x+1)), (-Inf,Inf)), # lfact only defined for integers
 (:lgamma, :(digamma.(x)), (-Inf,Inf)),
 (:digamma, :(trigamma.(x)), (-Inf,Inf)), # polygamma(0,x)
 (:trigamma, :(polygamma2.(x)), (-Inf,Inf)), # polygamma(1,x)
-(:invdigamma, :(1./trigamma.(y)), (-Inf,Inf)),
+(:invdigamma, :(1 ./ trigamma.(y)), (-Inf,Inf)),
 (:polygamma2, :(error()), (-Inf,Inf)),
 # zeta: TODO. Riemann 1-arg zeta
 # eta # TODO. related to zeta
@@ -13,13 +13,14 @@ gamma1arg = [
 polygamma2(x)=polygamma(2,x)
 
 for (f,g,r) in gamma1arg
-    bf = broadcast_func(f)
-    @eval @primitive $f(x),dy,y  (dy.*($g))
-    if bf != f
-        @eval @primitive $bf(x),dy,y  (dy.*($g))
-    end
-    if f != :polygamma2
-        addtest1(f,r)
+    let bf = broadcast_func(f)
+        @eval @primitive $f(x),dy,y  (dy.*($g))
+        if bf != f
+            @eval @primitive $bf(x),dy,y  (dy.*($g))
+        end
+        if f != :polygamma2
+            addtest1(f,r)
+        end
     end
 end
 
@@ -30,7 +31,7 @@ gamma2arg = [
 ]
 
 # polygamma wants x1 to be a non-negative integer, x2 unrestricted
-@primitive polygamma(x1,x2),dy,y  nothing  unbroadcast(x2,dy.*polygamma(x1+1,x2))
+@primitive polygamma(x1,x2),dy,y  nothing  unbroadcast(x2,dy .* polygamma(x1+1,x2))
 polygamma_(x,i)=polygamma(i,x)
 addtest(:polygamma_, randn(), rand(0:5))
 # TODO: add broadcasting version

--- a/src/special/trig.jl
+++ b/src/special/trig.jl
@@ -1,55 +1,56 @@
 trig1arg = [
-(:acos, :(-1./sqrt.(1-abs2.(x))), (-1,1)),
-(:acosd, :(-(180/pi)./sqrt.(1-abs2.(x))), (-1,1)),
-(:acosh, :(1./sqrt.(abs2.(x)-1)), (1,Inf)),
-(:acot, :(-1./(1+abs2.(x))), (-Inf,Inf)),
-(:acotd, :(-(180/pi)./(1+abs2.(x))), (-Inf,Inf)),
-(:acoth, :(1./(1-abs2.(x))), (-Inf,-1,1,Inf)),
-(:acsc, :(-1./sqrt.(x.*x.*(x-1).*(x+1))), (-Inf,-1,1,Inf)),
-(:acscd, :(-(180/pi)./sqrt.(x.*x.*(x-1).*(x+1))), (-Inf,-1,1,Inf)),
-(:acsch, :(-1./sqrt.(x.^4+x.^2)), (-Inf,Inf)),
-(:asec, :(1./sqrt.(x.^4-x.^2)), (-Inf,-1,1,Inf)),
-(:asecd, :((180/pi)./sqrt.(x.^4-x.^2)), (-Inf,-1,1,Inf)),
-(:asech, :(-1./sqrt.(x.^2-x.^4)), (0,1)),
-(:asin, :(1./sqrt.(1-abs2.(x))), (-1,1)),
-(:asind, :((180/pi)./sqrt.(1-abs2.(x))), (-1,1)),
-(:asinh, :(1./sqrt.(1+abs2.(x))), (-Inf,Inf)),
-(:atan, :(1./(1+abs2.(x))), (-Inf,Inf)),
-(:atand, :((180/pi)./(1+abs2.(x))), (-Inf,Inf)),
-(:atanh, :(1./(1-abs2.(x))), (-1,1)),
+(:acos, :(-1 ./ sqrt.(1 .- abs2.(x))), (-1,1)),
+(:acosd, :(-(180/pi) ./ sqrt.(1 .- abs2.(x))), (-1,1)),
+(:acosh, :(1 ./ sqrt.(abs2.(x) .- 1)), (1,Inf)),
+(:acot, :(-1 ./ (1 .+ abs2.(x))), (-Inf,Inf)),
+(:acotd, :(-(180/pi) ./ (1 .+ abs2.(x))), (-Inf,Inf)),
+(:acoth, :(1 ./ (1 .- abs2.(x))), (-Inf,-1,1,Inf)),
+(:acsc, :(-1 ./ sqrt.(x .* x .* (x .- 1) .* (x .+ 1))), (-Inf,-1,1,Inf)),
+(:acscd, :(-(180/pi) ./ sqrt.(x .* x .* (x .- 1) .* (x .+ 1))), (-Inf,-1,1,Inf)),
+(:acsch, :(-1 ./ sqrt.(x .^ 4+x .^ 2)), (-Inf,Inf)),
+(:asec, :(1 ./ sqrt.(x .^ 4-x .^ 2)), (-Inf,-1,1,Inf)),
+(:asecd, :((180/pi) ./ sqrt.(x .^ 4-x .^ 2)), (-Inf,-1,1,Inf)),
+(:asech, :(-1 ./ sqrt.(x .^ 2-x .^ 4)), (0,1)),
+(:asin, :(1 ./ sqrt.(1 .- abs2.(x))), (-1,1)),
+(:asind, :((180/pi) ./ sqrt.(1 .- abs2.(x))), (-1,1)),
+(:asinh, :(1 ./ sqrt.(1 .+ abs2.(x))), (-Inf,Inf)),
+(:atan, :(1 ./ (1 .+ abs2.(x))), (-Inf,Inf)),
+(:atand, :((180/pi) ./ (1 .+ abs2.(x))), (-Inf,Inf)),
+(:atanh, :(1 ./ (1 .- abs2.(x))), (-1,1)),
 (:cos, :(-sin.(x)), (-Inf,Inf)),
 # cos_kernel: Not exported
-(:cosc, :(-2y./x-sinc.(x)*(pi^2)), (-Inf,Inf)),
-(:cosd, :(-sind.(x)*pi/180), (-Inf,Inf)),
+(:cosc, :(-2y ./ x-sinc.(x)*(pi^2)), (-Inf,Inf)),
+(:cosd, :(-sind.(x) .* pi/180), (-Inf,Inf)),
 (:cosh, :(sinh.(x)), (-Inf,Inf)),
-(:cospi, :(-sinpi.(x)*pi), (-Inf,Inf)),
+(:cospi, :(-sinpi.(x) .* pi), (-Inf,Inf)),
 (:cot, :(-abs2.(csc.(x))), (-Inf,Inf)),
-(:cotd, :(-abs2.(cscd.(x))*pi/180), (-Inf,Inf)),
+(:cotd, :(-abs2.(cscd.(x)) .* pi/180), (-Inf,Inf)),
 (:coth, :(-abs2.(csch.(x))), (-Inf,Inf)),
-(:csc, :(-y.*cot.(x)), (-Inf,Inf)),
-(:cscd, :(-y.*cotd.(x)*pi/180), (-Inf,Inf)),
-(:csch, :(-y.*coth.(x)), (-Inf,Inf)),
+(:csc, :(-y .* cot.(x)), (-Inf,Inf)),
+(:cscd, :(-y .* cotd.(x) .* pi/180), (-Inf,Inf)),
+(:csch, :(-y .* coth.(x)), (-Inf,Inf)),
 # deg2rad_ext: Not exported
 # mulpi_ext: Not exported
-(:sec, :(y.*tan.(x)), (-Inf,Inf)),
-(:secd, :(y.*tand.(x)*pi/180), (-Inf,Inf)),
-(:sech, :(-y.*tanh.(x)), (-Inf,Inf)),
+(:sec, :(y .* tan.(x)), (-Inf,Inf)),
+(:secd, :(y .* tand.(x)*pi/180), (-Inf,Inf)),
+(:sech, :(-y .* tanh.(x)), (-Inf,Inf)),
 (:sin, :(cos.(x)), (-Inf,Inf)),
 # sin_kernel: Not exported
 (:sinc, :(cosc.(x)), (-Inf,Inf)), # sin(πx)/(πx)
-(:sind, :(cosd.(x)*pi/180), (-Inf,Inf)),
+(:sind, :(cosd.(x) .* pi/180), (-Inf,Inf)),
 (:sinh, :(cosh.(x)), (-Inf,Inf)),
-(:sinpi, :(cospi.(x)*pi), (-Inf,Inf)),
-(:tan, :(1+abs2.(y)), (-1,1)), # (-Inf,Inf)), sometimes fails when too close to pi/2 multiples
-(:tand, :((1+abs2.(y))*pi/180), (-Inf,Inf)),
-(:tanh, :(1-abs2.(y)), (-Inf,Inf)),
+(:sinpi, :(cospi.(x) .* pi), (-Inf,Inf)),
+(:tan, :(1 .+ abs2.(y)), (-1,1)), # (-Inf,Inf)), sometimes fails when too close to pi/2 multiples
+(:tand, :((1 .+ abs2.(y))*pi/180), (-Inf,Inf)),
+(:tanh, :(1 .- abs2.(y)), (-Inf,Inf)),
 ]
 
 for (f,g,r) in trig1arg
-    bf = broadcast_func(f)
-    @eval @primitive $f(x),dy,y  (dy.*($g))
-    if bf != f
-        @eval @primitive $bf(x),dy,y  (dy.*($g))
+    let bf = broadcast_func(f)
+        @eval @primitive $f(x),dy,y  (dy .* ($g))
+        if bf != f
+            @eval @primitive $bf(x),dy,y  (dy .* ($g))
+        end
+        addtest1(f,r)
     end
-    addtest1(f,r)
 end

--- a/src/unfuse.jl
+++ b/src/unfuse.jl
@@ -34,7 +34,7 @@ if VERSION < v"0.7.0-DEV.2635"
     broadcast(f, x::Union{Number,AbstractArray}...)=broadcast_c(f, containertype(x...), x...)
 else
     using Base.Broadcast: combine_styles
-    broadcast(f, x::Union{Number,AbstractArray}...)=broadcast(f, combine_styles(x...), nothing, nothing, x...)
+    broadcast(f, x::Union{Number,AbstractArray}...)=broadcast(f, Ref(combine_styles(x...)), nothing, nothing, x...)
 end
 # This captures cases where at least one arg is a Rec:
 broadcast(f, x::Union{Number,AbstractArray,Rec}...)=f(Broadcasted.(x)...).value

--- a/src/unfuse.jl
+++ b/src/unfuse.jl
@@ -24,13 +24,18 @@
 # 1. broadcast(F, x::Union{previous_types,T}...) = F(Broadcasted.(x)...).value
 # 2. bf(x::T) needs to be implemented (after being imported)
 
-type Broadcasted{T}
+mutable struct Broadcasted{T}
     value::T
 end
 getval(x::Broadcasted)=x.value
 # We need this to not override regular broadcast(f, A, Bs...):
-using Base.Broadcast: broadcast_c, containertype
-broadcast(f, x::Union{Number,AbstractArray}...)=broadcast_c(f, containertype(x...), x...)
+if VERSION < v"0.7.0-DEV.2635"
+    using Base.Broadcast: broadcast_c, containertype
+    broadcast(f, x::Union{Number,AbstractArray}...)=broadcast_c(f, containertype(x...), x...)
+else
+    using Base.Broadcast: combine_styles
+    broadcast(f, x::Union{Number,AbstractArray}...)=broadcast(f, combine_styles(x...), nothing, nothing, x...)
+end
 # This captures cases where at least one arg is a Rec:
 broadcast(f, x::Union{Number,AbstractArray,Rec}...)=f(Broadcasted.(x)...).value
 

--- a/test/header.jl
+++ b/test/header.jl
@@ -1,2 +1,4 @@
-using Base.Test
+using Compat
+using Compat.Test, Compat.LinearAlgebra
+pushfirst!(LOAD_PATH, joinpath(dirname(@__FILE__),"../src"))
 using AutoGrad

--- a/test/indexing.jl
+++ b/test/indexing.jl
@@ -5,7 +5,7 @@ include("header.jl")
     # info("Test indexing...")
 
     a1 = rand(3)                    # TODO: FAIL: some high-order (b1sum) tests with rand(2)
-    t1 = (a1...)
+    t1 = (a1...,)
     d1 = Dict(); for i=1:length(a1); d1[i]=a1[i]; end
 
     s0(x)=x[1]^2+x[2]^2

--- a/test/interfaces.jl
+++ b/test/interfaces.jl
@@ -45,14 +45,14 @@ include("header.jl")
 
     @testset "size" begin
         f0(x) = (p=size(x); p[1]*sum(x.^2))
-        @test grad(f0)(ones(3)) == fill(6, 3)
+        @test grad(f0)(fill(1.0,3)) == fill(6, 3)
 
         f1(x)=(p=size(x, 1); p*sum(x.^2))
-        @test grad(f1)(ones(3, 3)) == fill(6, 3, 3)
+        @test grad(f1)(fill(1.0, 3, 3)) == fill(6, 3, 3)
 
         # issue #18
         f2(x)=(p=size(x, 1, 2); p[1]*sum(x.^2))
-        @test grad(f2)(ones(3, 3)) == fill(6, 3, 3)
+        @test grad(f2)(fill(1.0, 3, 3)) == fill(6, 3, 3)
     end
 
     @testset "1arg_type" begin

--- a/test/neuralnet.jl
+++ b/test/neuralnet.jl
@@ -6,7 +6,7 @@ n1 = grad(n0)
 n1sum(w,x,y)=sum(map(sum,n1(w,x,y)))
 n1sumd(w,x,y)=sum(map(sum,values(n1(w,x,y))))
 wa = Any[rand(2,3),rand(2),rand(2,2),rand(2)]
-wt = (wa...)
+wt = (wa...,)
 wd = Dict(); for i=1:length(wa); wd[i]=wa[i]; end
 
 @testset "neuralnet" begin

--- a/test/primitives.jl
+++ b/test/primitives.jl
@@ -1,7 +1,7 @@
 include("header.jl")
 
 @testset "primitives" begin
-for t in AutoGrad.alltests()
+    for t in AutoGrad.alltests()
         @test gradcheck(eval(AutoGrad,t.f), t.args...; kwargs = t.kargs)
     end
 end

--- a/test/primitives.jl
+++ b/test/primitives.jl
@@ -1,9 +1,8 @@
 include("header.jl")
 
 @testset "primitives" begin
-    for t in AutoGrad.alltests()
-        #@show t
-        @test gradcheck(eval(AutoGrad,t[1]), t[2:end]...)
+for t in AutoGrad.alltests()
+        @test gradcheck(eval(AutoGrad,t.f), t.args...; kwargs = t.kargs)
     end
 end
 

--- a/test/rosenbrock.jl
+++ b/test/rosenbrock.jl
@@ -3,7 +3,7 @@ include("header.jl")
 @testset "rosenbrock" begin
     # info("Test rosenbrock with map...")
     a1 = rand(3)                    # TODO: FAIL: some high-order (b1sum) tests with rand(2)
-    t1 = (a1...)
+    t1 = (a1...,)
     d1 = Dict(); for i=1:length(a1); d1[i]=a1[i]; end
     b0(x) = sum(map((i, j) -> (1 - j)^2 + 100*(i - j^2)^2, x[2:end], x[1:end-1]))
     b1 = grad(b0)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,4 @@
+println("-------\n\n\n")
 # Uncomment these if you want lots of messages:
 # import Base.Test: default_handler, Success, Failure, Error
 # default_handler(r::Success) = info("$(r.expr)")
@@ -10,3 +11,5 @@ include("rosenbrock.jl")
 include("highorder.jl")
 include("neuralnet.jl")
 include("primitives.jl")
+
+println("done!\n\n")


### PR DESCRIPTION
Trying to address #65, I updated the code generation macros and fixed as many of the deprecation warnings as I could. Almost all unit tests pass, except for 4 related to svd backpass.

I do not know how to handle the changes required for the move from `sum(x, d)` to `sum(x, dims = d)` et al, as I could not figure out how to deal with the keyword arguments.

For anyone looking into this, running julia with `--depwarn=error` helps a lot as it allows to see where a deprecation is triggered due to the resulting stack traces.