### PR TITLE
Tape confusion fix

### DIFF
--- a/src/core.jl
+++ b/src/core.jl
@@ -77,6 +77,7 @@ function forward_pass(fun, args, kwargs, argnum)
     tape = Tape()
     arg_wrt = args[argnum]
     if isa(arg_wrt,Rec)
+        arg_wrt = identity(arg_wrt)
         Node(arg_wrt, tape)
         start_box = arg_wrt
     else

--- a/src/util.jl
+++ b/src/util.jl
@@ -315,6 +315,8 @@ fillvalues(v,x)=(y=similar(x);for k in keys(x); y[k]=v; end; y)
 addtest(:sumvalues, Dict(1=>1.,2=>2.))
 addtest(:fillvalues, 0., Dict(1=>1.,2=>2.,3=>3.))
 
+@primitive identity(x),dy dy
+
 # This needs more work:
 # @primitive values(x),dy Dict(map((a,b)->(a=>b), keys(x), dy))
 


### PR DESCRIPTION
This fixes a silent bug where

```julia
grad(x -> x*grad(y -> x+y)(x))(5.0) == 2
grad(x -> x*grad(y -> x+y)(1x))(5.0) == 1
```

(the correct answer is 1).